### PR TITLE
HomeWork11-Tree

### DIFF
--- a/tree/4803-트리/1.kt
+++ b/tree/4803-트리/1.kt
@@ -1,0 +1,74 @@
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.util.*
+
+val br = BufferedReader(InputStreamReader(System.`in`))
+val bw = BufferedWriter(OutputStreamWriter(System.out))
+lateinit var graph : MutableList<MutableList<Int>>
+lateinit var visited: BooleanArray
+var case = 0
+fun main() {
+    while (true) {
+        var ans = 0
+        // 초기화
+        val (n, m) = br.readLine().split(" ").map { it.toInt() }
+        visited = BooleanArray(n+1).apply { set(0, true) } // 노드의 방문기록 
+        graph = mutableListOf<MutableList<Int>>().apply { // 인접리스트 방식으로 그래프의 연결방식을 표현
+            repeat(n+1) {
+                add(mutableListOf())
+            }
+        }
+        case++
+        if (n == 0 && m == 0) {
+            bw.flush()
+            bw.close()
+            br.close()
+            return
+        }
+        repeat(m) {
+            val (a, b) = br.readLine().split(" ").map { it.toInt() }
+            graph[a].add(b)
+            graph[b].add(a)
+        }
+        repeat(n + 1) lab@{ idx ->
+            if (idx == 0) return@lab
+
+            if (!visited[idx] && !bfs(idx)) {
+                ans++
+            }
+        }
+        when (ans) {
+            0 -> {
+                bw.write("Case $case: No trees.\n")
+            }
+            1 -> {
+                bw.write("Case $case: There is one tree.\n")
+            }
+            else -> {
+                bw.write("Case $case: A forest of $ans trees.\n")
+            }
+        }
+    }
+}
+
+private fun bfs(node: Int): Boolean {
+    var isCycle = false
+    val q = LinkedList<Int>().apply { add(node) }
+
+    while (q.isNotEmpty()) {
+        val curNode = q.poll()
+        if(visited[curNode]){
+            isCycle = true
+        }
+        visited[curNode] = true
+        for (nextNode in graph[curNode]) {
+            if (!visited[nextNode]) {
+                q.add(nextNode)
+            }
+        }
+    }
+    return isCycle
+}
+

--- a/tree/4803-트리/1.py
+++ b/tree/4803-트리/1.py
@@ -1,0 +1,67 @@
+import sys
+
+input = lambda: sys.stdin.readline().rstrip()
+write = lambda x: sys.stdout.write(str(x))
+
+
+# n : 500, m: n(n-1)/ 2
+# 0, 0 종료
+# 정점 번호 1부터 시작
+# 트리의 개수 구하는 문제!!
+# dfs로도 풀 수 있음
+# 하지만 나는 disjoint로 품 ㅎ ㅎ
+
+def findParent(node):
+    if (parent[node] <= 0): return node
+    # 경로 압축
+    parent[node] = findParent(parent[node])
+    return parent[node]
+
+
+def union(node1, node2):
+    parent_node1 = findParent(node1)  # node1의 부모 노드
+    parent_node2 = findParent(node2)  # node2의 부모 노드
+
+    if (parent_node1 == parent_node2):
+        parent[parent_node1] = 0
+        return False
+    if (parent[parent_node1] == 0):
+        parent[parent_node2] = 0
+        return False
+    if (parent[parent_node2] == 0):
+        parent[parent_node1] = 0
+        return False
+
+    if (parent[parent_node1] <= parent[parent_node2]):
+        parent[parent_node1] += parent[parent_node2]
+        parent[parent_node2] = parent_node1
+    else:
+        parent[parent_node2] += parent[parent_node1]
+        parent[parent_node1] = parent_node2
+    return True
+
+
+def printTreeNum(cnt, caseNum):
+    write("Case {0}: ".format(caseNum))
+    if (cnt == 0):
+        write("No trees.\n")
+    elif (cnt == 1):
+        write("There is one tree.\n")
+    else:
+        write("A forest of {0} trees.\n".format(cnt))
+
+
+caseNum = 0
+while (True):
+    caseNum += 1
+    n, m = map(int, input().split())
+    cnt = 0
+    if ((n, m) == (0, 0)): break
+    parent = [0] + [-1] * (n)
+    for i in range(m):
+        a, b = map(int, input().split())
+        union(a, b)
+
+    for v in parent:
+        if (v < 0): cnt += 1
+    printTreeNum(cnt, caseNum)


### PR DESCRIPTION
# 4803- [트리](https://www.acmicpc.net/problem/4803)
- 일단 생각보다 너무 어려운 문제를 낸거 같아 사죄의 말씀...을 드립니다.
- 이 문제는 결국 비순환 그래프의 개수를 구하는 문제이다.
- 따라서, 해당 그래프가 cycle이 있는지 없는지만 판별하면 되는 문제이다.
- 코틀린으로는 BFS방식, 파이썬으로는 Disjoint-Set 방식으로 문제를 풀었으나  Disjoint-Set은 난이도가 좀 있는 관계로 BFS풀이만 간략하게 설명하겠습니당
# BFS (너비 우선 ) 간략하게만 알아봐요~
목적: 모든 정점을 한 번씩 탐색 , 모든 가중치가 1일 때 최단 거리를 찾는 알고리즘이다.  

BFS는 너비 우선 탐색이라고도 부르며, 그래프에서 가까운 노드부터 우선적으로 탐색하는 알고리즘이다.  
BFS는 큐 자료구조를 이용하며, 구체적인 동작 과정은 다음과 같다.
```
1. 탐색 시작 노드를 큐에 삽입하고 방문 처리를 한다.
2. 큐에서 노드를 꺼낸(제거한) 후, 노드의 인접 노드 중에서 방문하지 않은 노드를 모두 큐에 삽입한다.
3. 삽입한 노드들도 순차적으로 1,2번 과정을 처리한다.
4. 더 이상 2번의 과정을 수행할 수 없을 때까지 반복한다.

```
## 트리 코틀린 풀이(BFS)
- visited: 모든 노드의 체크 여부를 배열에 저장했습니다~
```kotlin
visited = BooleanArray(501).apply { set(0, true) }
```
- graph : 각 노드가 연결된 정보를 인접리스트 방식으로 저장하였습니다.
```kotlin
graph = mutableListOf<MutableList<Int>>().apply {
            repeat(501) {
                add(mutableListOf())
            }
        }
```
- 문제에서 주어진 모든 정점과 연결된 그래프를 BFS 방식으로 탐색합니다
```kotlin
repeat(n + 1) lab@{ idx ->
            if (idx == 0) return@lab
            // 모든 정점들 한번씩 bfs 돌리기!
            if (!visited[idx] && !bfs(idx)) { 
                ans++
            }
        }
```
- DFS 방식으로 풀이를 해도 괜찮다 😄 
- 저는 재귀를 쓰기 싫어서 BFS 방식으로 풀었습니다~
- 간단하게 설명하자면, `node 노드를 포함하는 그래프`의 모든 정점을 한 번씩 탐색하여 해당 그래프가 cylce이 있는지 없는지 체크하는 방식입니다.
```kotlin
private fun bfs(node: Int): Boolean {
    var isCycle = false
// 큐 구현을 위해 링크드리스트 자료구조를 사용
    val q = LinkedList<Int>().apply { add(node) }

    while (q.isNotEmpty()) {
        val curNode = q.poll()
// 이미 방문한 노드이면 cycle이 발생했다는 의미!!
        if(visited[curNode]){
            isCycle = true
        }
        visited[curNode] = true
    //  아직 방문하지 않은 인접한 원소들을 큐에 삽입
        for (nextNode in graph[curNode]) {
            if (!visited[nextNode]) {
                q.add(nextNode)
            }
        }
    }
    return isCycle
}

```
