### PR TITLE
HomeWork22-graph

### DIFF
--- a/graph/2468-안전 영역.kt
+++ b/graph/2468-안전 영역.kt
@@ -1,0 +1,98 @@
+package org.techtown.practice_mvvm_event.algorithm
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.lang.Integer.max
+import java.util.*
+
+// N은 2 이상 100 이하의 정수
+// 높이는 1이상 100 이하의 정수이다.
+val br = BufferedReader(InputStreamReader(System.`in`))
+val bw = BufferedWriter(OutputStreamWriter(System.out))
+
+private var n = 0
+private var ans = 1
+private var graph = mutableListOf<List<Int>>()
+private var visited = mutableListOf<IntArray>()
+private var height = 0
+private val dx = listOf(1, 0, 0, -1)
+private val dy = listOf(0, 1, -1, 0)
+fun main() {
+    n = br.readLine().toInt()
+    repeat(n) {
+        graph.add(br.readLine().split(" ").map { it.toInt() })
+    }
+    repeat(100) { it ->
+        height = it + 1
+        repeat(n) {
+            visited.add(
+                IntArray(n) {
+                    -1
+                }
+            )
+        }
+        // 0 이면 height보다 작은 녀석들 싹다 0으로 바꾸기
+        // heiht보다 크면 주변 녀석들 싹다 result로 바꾸기
+        var result = 1
+        repeat(n) { i ->
+            repeat(n) { j ->
+                if (visited[i][j] == -1) {
+                    if (graph[i][j] <= height) {
+                        visited[i][j] = 0
+                        bfs(i, j)
+                    } else {
+                        visited[i][j] = result
+                        bfs(i, j, result)
+                        result++
+                    }
+                }
+            }
+        }
+        ans = max(ans, result - 1)
+        visited.clear()
+    }
+    bw.write("$ans\n")
+    bw.flush()
+    br.close()
+    bw.close()
+}
+
+private fun bfs(i: Int, j: Int) {
+    val queue = LinkedList<List<Int>>().apply {
+        push(listOf(i, j))
+    }
+    while (queue.isNotEmpty()) {
+        val (x, y) = queue.poll()!!
+        repeat(4) {
+            val n_x = x + dx[it]
+            val n_y = y + dy[it]
+            if (n_x in (0..n - 1) && n_y in (0..n - 1)) {
+                if (visited[n_x][n_y] == -1 && graph[n_x][n_y] <= height) {
+                    visited[n_x][n_y] = 0
+                    queue.push(listOf(n_x, n_y))
+                }
+            }
+        }
+    }
+}
+
+private fun bfs(i: Int, j: Int, result: Int) {
+    val queue = LinkedList<List<Int>>().apply {
+        add(listOf(i, j))
+    }
+    while (queue.isNotEmpty()) {
+        val (x, y) = queue.poll()!!
+        repeat(4) {
+            val n_x = x + dx[it]
+            val n_y = y + dy[it]
+            if (n_x in (0..n - 1) && n_y in (0..n - 1)) {
+                if (visited[n_x][n_y] == -1 && graph[n_x][n_y] > height) {
+                    visited[n_x][n_y] = result
+                    queue.push(listOf(n_x, n_y))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 2468-[안전 영역](https://www.acmicpc.net/problem/2468). 
- 주어진 height의 길이와 n의 범위를 체크한 후, bfs 풀이로 충분히 풀이가 가능함을 인지하고 bfs를 사용해서 풀이하였습니다.    
- 시간복잡도 : O(100*O(N^2))   
    - BFS의 시간복잡도는 O(V+E)입니다. 위 풀이에서  V, E가 N^2 이하이기 떄문에 O(N^2)로 치환할 수 있겠습니다 :D. 

많이 더러운 풀이입니다.. 간략하게 설명을 하자면. 
- height가 1~100의 범위를 갖기 때문에, repeat(100)의 반복문을 돌면서, bfs를 통해 안전 구역의 개수를 구한 후 result에 저장합니다. 그 후,  ans와 max함수를 통해 비교하여 더 큰 값을 저장합니다.  
- bfs함수가 2개가 있는데, 하나는 조건을 만족하는 노드의 visited를 모두 `0으`로 바꿔줍니다.(`0은 물에 잠긴 상태를 의미`합니다.). 
- 다른 하나는 조건을 만족하는 노드의 visited를 모두  `result` 로 바꿔줍니다. (`result는 안전 구역의 번호`입니다.). 
- 참고로, 저는 visited를 `-1`로 초기화하였는데 여기서 -1는 `방문하지 않은 노드의 상태`를 의미합니다.   

사실 bfs함수를 하나만 사용해도 충분히 풀이 할 수 있었는데 한 함수에 if문이 너무 많아지면 어지러워서 2개의 bfs 함수를 만들었습니다 헷
